### PR TITLE
Use Stdlib::Absolutepath instead of Stdlib::Compat::Absolutepath

### DIFF
--- a/lib/facter/tuned.rb
+++ b/lib/facter/tuned.rb
@@ -10,8 +10,11 @@ Facter.add('tuned_version') do
     out = Facter::Core::Execution.exec('tuned --version 2>&1')
     if out && out =~ %r{^tuned ([\d\.]+)$}i
       Regexp.last_match(1)
-    elsif !Facter::Core::Execution.exec('which tuned 2>/dev/null').empty?
-      'unknown'
+    else
+      out = Facter::Core::Execution.exec('which tuned 2>/dev/null')
+      if ! out || out.empty?
+        'unknown'
+      end
     end
   end
 end
@@ -33,7 +36,7 @@ Facter.add('tuned_profile') do
       ]
 
       alternatives.each do |fn|
-        if FileTest.exists?(fn) && !File.empty?(fn)
+        if File.exist?(fn) && !File.empty?(fn)
           result = File.foreach(fn).first.chomp
           break
         end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,7 @@ class tuned (
   Integer $sleep_interval                                        = $tuned::params::sleep_interval,
   Integer $update_interval                                       = $tuned::params::update_interval,
   String $majversion                                             = $tuned::params::majversion,
-  Variant[Stdlib::Compat::Absolute_path, String[0,0]] $main_conf = $tuned::params::main_conf,
+  Variant[Stdlib::Absolutepath, String[0,0]] $main_conf          = $tuned::params::main_conf,
   Stdlib::Absolutepath $profiles_path                            = $tuned::params::profiles_path,
   String $active_profile_conf                                    = $tuned::params::active_profile_conf,
   Array[String, 1] $packages                                     = $tuned::params::packages,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,7 +4,7 @@ class tuned::install {
     false => absent
   }
 
-  ensure_packages($tuned::packages, {
+  stdlib::ensure_packages($tuned::packages, {
     ensure => $_ensure,
   })
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,7 +4,11 @@ class tuned::params {
   $sleep_interval = 1
   $update_interval = 10
 
-  if has_key($facts, 'tuned_version') and $facts['tuned_version'] =~ /^(\d+)\.[\d\.]+$/ {
+    $my_hash = {'key_one' => 'value_one'}
+    if 'key_one' in $my_hash {
+      notice('this will be printed')
+    }
+  if 'tuned_version' in $facts and $facts['tuned_version'] =~ /^(\d+)\.[\d\.]+$/ {
     $_majversion = $1
   } else {
     $_majversion = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,10 +4,6 @@ class tuned::params {
   $sleep_interval = 1
   $update_interval = 10
 
-    $my_hash = {'key_one' => 'value_one'}
-    if 'key_one' in $my_hash {
-      notice('this will be printed')
-    }
   if 'tuned_version' in $facts and $facts['tuned_version'] =~ /^(\d+)\.[\d\.]+$/ {
     $_majversion = $1
   } else {


### PR DESCRIPTION
Using stdlib >=9.0.0 will fail due to a resource not found error for Stdlib::Compat::Absolutepath